### PR TITLE
Add /links page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/css/style.css
+++ b/css/style.css
@@ -14,4 +14,6 @@ body {
   color: #BA0046;
 }
 
-
+ul#peopleOfInterest > li > a {
+    color:black!important;
+}

--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
       @benjaminparnell</a> or <a href="https://twitter.com/swapnull">@swapnull</a>
       and they will be happy to help.
     </p>
+
+    <p>
+      Also, check out our <a href="/links/">link dump</a>!
+    </p>
   </div>
 </body>
 </html>

--- a/links/index.html
+++ b/links/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>shuprog</title>
+  <link rel="stylesheet" href="/css/normalize.css" media="all">
+  <link rel="stylesheet" href="/css/skeleton.css" media="all">
+  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="/css/style.css" media="all">
+</head>
+<body>
+  <a href="https://github.com/shuprog"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+  <div class="container">
+    <header class="row">
+      <h1 class="logo">shuprog link dump</h1>
+      <p>
+        Here is a list of links that we think are pretty cool.
+      </p>
+    </header>
+
+    <h4>Videos</h4>
+    <ul>
+      <li>
+        <a href="https://www.youtube.com/watch?v=UIDb6VBO9os">What is open source and why do I feel so guilty?</a> by
+        <a href="http://twitter.com/fat">fat</a>
+      </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/links/index.html
+++ b/links/index.html
@@ -1,30 +1,74 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>shuprog</title>
-  <link rel="stylesheet" href="/css/normalize.css" media="all">
-  <link rel="stylesheet" href="/css/skeleton.css" media="all">
-  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="/css/style.css" media="all">
-</head>
-<body>
-  <a href="https://github.com/shuprog"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
-  <div class="container">
-    <header class="row">
-      <h1 class="logo">shuprog link dump</h1>
-      <p>
-        Here is a list of links that we think are pretty cool.
-      </p>
-    </header>
 
-    <h4>Videos</h4>
-    <ul>
-      <li>
-        <a href="https://www.youtube.com/watch?v=UIDb6VBO9os">What is open source and why do I feel so guilty?</a> by
-        <a href="http://twitter.com/fat">fat</a>
-      </li>
-    </ul>
-  </div>
+<head>
+    <meta charset="UTF-8">
+    <title>shuprog</title>
+    <link rel="stylesheet" href="../css/normalize.css" media="all">
+    <link rel="stylesheet" href="../css/skeleton.css" media="all">
+    <link href='https://fonts.goapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="../css/style.css" media="all">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+</head>
+
+<body>
+    <a href="https://github.com/shuprog"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"
+        alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+    <div class="container">
+        <header class="row">
+            <h1 class="logo">shuprog link dump</h1>
+            <p>
+                Here is a list of links that we think are pretty cool.
+            </p>
+        </header>
+
+        <h4>Videos</h4>
+        <ul>
+            <li>
+                <a href="https://www.youtube.com/watch?v=UIDb6VBO9os">What is open source and why do I feel so guilty?</a> by
+                <a href="http://twitter.com/fat">fat</a>
+            </li>
+            <li>
+                <a href="https://www.youtube.com/watch?v=20BySC_6HyY">Wat?</a> by
+                <a href="https://twitter.com/garybernhardt">Gary Bernhardt</a>
+            </li>
+            <li>
+                <a href="https://www.youtube.com/watch?v=FKTxC9pl-WM">Making Badass Developers</a> by
+                <a href="http://seriouspony.com/blog/">Kathy Sierra</a>
+            </li>
+        </ul>
+        <h4>People of Interest</h4>
+        <ul id="peopleOfInterest">
+            <li>
+                <strong>Jeff Atwood</strong><br>
+                <a href="http://blog.codinghorror.com/" title="blog"><i class="fa fa-rss-square fa-2x"></i></a>
+                <a href="https://twitter.com/codinghorror" title="twitter"><i class="fa fa-twitter-square fa-2x"></i></a>
+            </li>
+            <li>
+                <strong>Scott Hanselman</strong><br>
+                <a href="http://www.hanselman.com/blog/" title="blog"><i class="fa fa-rss-square fa-2x"></i></a>
+                <a href="https://twitter.com/shanselman" title="twitter"><i class="fa fa-twitter-square fa-2x"></i></a>
+                <a href="https://www.facebook.com/scott.hanselman" title="facebook"><i class="fa fa-facebook-square fa-2x"></i></a>
+            </li>
+            <li>
+                <strong>Melanie Richards</strong><br>
+                <a href="http://melanie-richards.com/blog" title="blog"><i class="fa fa-rss-square fa-2x"></i></a>
+                <a href="https://twitter.com/somelaniesaid" title="twitter"><i class="fa fa-twitter-square fa-2x"></i></a>
+                <a href="https://dribbble.com/melanierichards" title="dribbble"><i class="fa fa-dribbble fa-2x"></i></a>
+            </li>
+            <li>
+                <strong>Jacob Thornton (fat)</strong><br>
+                <a href="http://byfat.xxx/" title="blog"><i class="fa fa-rss-square fa-2x"></i></a>
+                <a href="https://twitter.com/fat" title="twitter"><i class="fa fa-twitter-square fa-2x"></i></a>
+                <a href="https://github.com/fat" title="github"><i class="fa fa-github-square fa-2x"></i></a> 
+            </li>
+        </ul>
+    </div>
+    <li>
+        <strong></strong><br>
+        <a href=""></a>
+        <a href=""></a>
+    </li>
 </body>
+
 </html>


### PR DESCRIPTION
This PR adds a basic links page, currently containing only one link.

The idea would be a list of links split by category - I currently have the 
category `Video`, but it might be better to go for categories like `Tutorial`
and `Misc` instead.

@niksudan @swapnull can you guys review and add any links to this PR you can
think of? Clone this branch and commit to this PR directly if you like.
